### PR TITLE
Rename initialize to initializePackage

### DIFF
--- a/lib/notebook.coffee
+++ b/lib/notebook.coffee
@@ -31,14 +31,14 @@ module.exports =
             # Setup the Notepads object
             @notepads = new Notepads()
 
-            # Call initialize to setup commands & event handlers
-            @initialize()
+            # Call initializePackage to setup commands & event handlers
+            @initializePackage()
         else
             # Throw an error for the benefit of package manager activePackage
             throw { stack: "- Notebook is active & functional only with a valid project open" }
 
     ### INITIALIZE ###
-    initialize: ->
+    initializePackage: ->
         # Setup the commands
         # Notepad Core Actions
         atom.workspaceView.command "notebook:new-notepad", => @notepads.new()


### PR DESCRIPTION
As of Atom 1.14, any method named `initialize` on the main module of a package will be automatically invoked by Atom before calling `activate`. You can read more about the change in this [pull request to Atom's documentation](https://github.com/atom/flight-manual.atom.io/pull/300/files).

Since your package's `initialize` method wasn't written with this behavior in mind, we've renamed it for you to avoid unexpected breakage.

Atom 1.14 should reach the beta channel in early January 2017 and will be on stable in early February 2017. Please merge and test out this PR before then to prevent issues, and let us know if you have any questions.

Thanks for your contributions to the Atom community! :bow:

/cc: @skulled 